### PR TITLE
Add obj and exe to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 ## Build files
+*.obj
+*.exe
 *.a
 build/
 build_gcc/


### PR DESCRIPTION
## Description
Windows related files should be excluded from git upload.

## Related Issue
None.

## Motivation and Context
If compiling for Windows, it is likely that EXE and OBJ files will be generated (and should not be uploaded).

## How Has This Been Tested?
None required.

## Screenshots (if appropriate):