### PR TITLE
Fix Doxygen warnings in controller subsystem.

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -56,7 +56,11 @@
 #define ERROR_NOT_PRESENT   0x2
 /** @} */
 
-/** @brief SI Controller Data */
+/**
+ * @brief SI Nintendo 64 controller data
+ * 
+ * Data structure for Joybus response to `0x01` (Read N64 controller state) command.
+ */
 typedef struct SI_condat
 {
     /** @brief Unused padding bits */
@@ -113,7 +117,11 @@ typedef struct SI_condat
     };
 } _SI_condat;
 
-/** @brief SI Controller Data, GC */
+/**
+ * @brief SI GameCube controller data.
+ * 
+ * Data structure for Joybus response to `0x40` (Read GC controller state) command.
+ */
 typedef struct SI_condat_gc
 {
     union
@@ -151,6 +159,11 @@ typedef struct SI_condat_gc
     };
 } _SI_condat_gc;
 
+/**
+ * @brief SI GameCube controller origin data.
+ * 
+ * Data structure for Joybus response to `0x41` (Read GC controller origin) command.
+ */
 struct SI_origdat_gc {
     struct SI_condat_gc data;
     uint8_t deadzone0;
@@ -158,20 +171,25 @@ struct SI_origdat_gc {
 };
 
 /**
- * @brief Structure for interpreting SI responses
+ * @brief SI controller data for all controller ports.
+ * 
+ * When reading N64 controller state, only the `c` member array will be populated.
+ * When reading GC controller state, only the `gc` member array will be populated.
  */
 typedef struct controller_data
 {
-    /** @brief Controller Data */
+    /** @brief Array of N64 controller state for each controller port. */
     struct SI_condat c[4];
-    /** @brief Padding or GC data to allow mapping directly to a PIF block */
+    /** @brief Array of GameCube controller state for each controller port. */
     struct SI_condat_gc gc[4];
-} _controller_data;
+} SI_controllers_state_t;
 
-struct controller_origin_data
+/** @brief SI GameCube controller origin data for all controller ports. */
+typedef struct controller_origin_data
 {
+    /** @brief Array of GameCube controller origin data for each controller port. */
     struct SI_origdat_gc gc[4];
-};
+} SI_controllers_origin_t;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/controller.c
+++ b/src/controller.c
@@ -195,8 +195,8 @@ void controller_scan( void )
 /**
  * @brief Get keys that were pressed since the last inspection
  *
- * Return keys pressed since last detection.  This returns a standard
- * #controller_data struct identical to #controller_read.  However, buttons
+ * Return keys pressed since last detection. This returns a standard
+ * #SI_controllers_state_t struct identical to #controller_read. However, buttons
  * are only set if they were pressed down since the last #controller_scan.
  *
  * @return A structure representing which buttons were just pressed down
@@ -220,8 +220,8 @@ struct controller_data get_keys_down( void )
 /**
  * @brief Get keys that were released since the last inspection
  *
- * Return keys released since last detection.  This returns a standard
- * #controller_data struct identical to #controller_read.  However, buttons
+ * Return keys released since last detection. This returns a standard
+ * #SI_controllers_state_t struct identical to #controller_read. However, buttons
  * are only set if they were released since the last #controller_scan.
  *
  * @return A structure representing which buttons were just released
@@ -245,8 +245,8 @@ struct controller_data get_keys_up( void )
 /**
  * @brief Get keys that were held since the last inspection
  *
- * Return keys held since last detection.  This returns a standard
- * #controller_data struct identical to #controller_read.  However, buttons
+ * Return keys held since last detection. This returns a standard
+ * #SI_controllers_state_t struct identical to #controller_read. However, buttons
  * are only set if they were held since the last #controller_scan.
  *
  * @return A structure representing which buttons were held


### PR DESCRIPTION
Doxygen documentation says that you can refer to a typedef'd-struct by its StructName or its TypeName, but this does not appear to be working for `controller_data`.

As a workaround, I have set a more-idiomatic TypeName for `struct controller_data` and switched the documentation to use the TypeName, however I decided not to update the usage of `struct controller_data` to `SI_controllers_state_t` to keep this changeset minimal.