### PR TITLE
Fix Transfer Pak macro #define group references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tools/mksprite/convtool
 tools/mksprite/mksprite
 tools/n64tool
 tools/**/*.exe
+website/ref/
 
 ## OSX junk
 .DS_Store

--- a/include/tpak.h
+++ b/include/tpak.h
@@ -10,7 +10,8 @@
 #include "libdragon.h"
 
 /**
- * @defgroup TPAK_ERROR Transfer Pak error values
+ * @anchor TPAK_ERROR
+ * @name Transfer Pak error values
  * @{
  */
 /** @brief Transfer Pak error: Invalid argument */
@@ -28,7 +29,8 @@
 /** @} */
 
 /**
- * @defgroup TPAK_STATUS Transfer Pak status bits
+ * @anchor TPAK_STATUS
+ * @name Transfer Pak status bits
  * @{
  */
 /**

--- a/src/tpak.c
+++ b/src/tpak.c
@@ -36,7 +36,8 @@
  */
 
 /**
- * @defgroup TPAK_POWER Transfer Pak power control values
+ * @anchor TPAK_POWER
+ * @name Transfer Pak power control values
  * 
  * @see #tpak_set_power
  * @{
@@ -48,7 +49,8 @@
 /** @} */
 
 /**
- * @defgroup TPAK_ADDRESS Transfer Pak address values
+ * @anchor TPAK_ADDRESS
+ * @name Transfer Pak address values
  * @{
  */
 /** @brief Transfer Pak address for power control */


### PR DESCRIPTION
The reason why I used `@defgroup` was so that the grouping could be linked with `@ref`. But I did not intend for these to be module-level groupings, so instead I have switched them back to `@name` member groups, but now with an `@anchor` so that they can be auto-linked.