### PR TITLE
Update CI for latest GH workflow changes

### DIFF
--- a/.github/actions/path-diff/action.yml
+++ b/.github/actions/path-diff/action.yml
@@ -1,3 +1,6 @@
+# Copyright (c) libdragon and contributers 2023
+# See LICENSE file in the project root for full license information.
+
 name: "Git diff"
 description: "Compares provided paths (optional) for given git refs/commits."
 inputs:
@@ -19,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -31,4 +34,4 @@ runs:
         ${{ inputs.base }} \
         ${{ inputs.head }} \
         -- ${{ inputs.paths }}
-        echo "::set-output name=exitCode::$?"
+        echo "exitCode=$?" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,3 +1,6 @@
+# Copyright (c) libdragon and contributers 2023
+# See LICENSE file in the project root for full license information.
+
 on:
   workflow_call:
     secrets:
@@ -17,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set variables
         id: vars
         run: |
-          echo "::set-output name=default_ref::${{ format('refs/heads/{0}', github.event.repository.default_branch) }}"
+          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@1.9.4

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 
       - name: Set variables
         id: vars

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -1,3 +1,6 @@
+# Copyright (c) libdragon and contributers 2023
+# See LICENSE file in the project root for full license information.
+
 on: workflow_call
 
 jobs:
@@ -20,7 +23,7 @@ jobs:
            mingw-w64-${{ matrix.arch }}-toolchain
          update: true
 
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v3
        with:
          fetch-depth: 0
 

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -9,36 +9,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       include: [
-         { sys: mingw64, arch: x86_64, build: tools},
-         { sys: mingw32, arch: i686,   build: tools}
-       ]
+        include: [
+          { sys: mingw64, arch: x86_64, build: tools},
+          { sys: mingw32, arch: i686,   build: tools}
+        ]
     steps:
-     - uses: msys2/setup-msys2@v2
-       with:
-         msystem: ${{matrix.sys}}
-         install: >-
-           mingw-w64-${{ matrix.arch }}-libpng
-           base-devel
-           mingw-w64-${{ matrix.arch }}-toolchain
-         update: true
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          install: >-
+            mingw-w64-${{ matrix.arch }}-libpng
+            base-devel
+            mingw-w64-${{ matrix.arch }}-toolchain
+          update: true
 
-     - uses: actions/checkout@v3
-       with:
-         fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 
-     - name: Correct MSYS2 pthread.h to allow static libraries (otherwise you would need to use a lib DLL, rather than it being built into the EXE.)
-       shell: msys2 {0}
-       run: |
-         sed -z 's/#else\n#define WINPTHREAD_API __declspec(dllimport)/#else\n#define WINPTHREAD_API/' /${{matrix.sys}}/include/pthread.h
+      - name: Correct MSYS2 pthread.h to allow static libraries (otherwise you would need to use a lib DLL, rather than it being built into the EXE.)
+        shell: msys2 {0}
+        run: |
+          sed -z 's/#else\n#define WINPTHREAD_API __declspec(dllimport)/#else\n#define WINPTHREAD_API/' /${{matrix.sys}}/include/pthread.h
 
-     - name: Build ${{ matrix.build }}
-       shell: msys2 {0}
-       run: |
-         make ${{ matrix.build }}
+      - name: Build ${{ matrix.build }}
+        shell: msys2 {0}
+        run: |
+          make ${{ matrix.build }}
 
-     - name: "Upload ${{ matrix.build }} executables"
-       uses: actions/upload-artifact@v2
-       with:
-         name: windows-${{ matrix.arch }}-${{ matrix.build }}
-         path: ${{ github.workspace }}/**/tools/**/*.exe
+      - name: "Upload ${{ matrix.build }} executables"
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-${{ matrix.arch }}-${{ matrix.build }}
+          path: ${{ github.workspace }}/**/tools/**/*.exe

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -38,7 +38,7 @@ jobs:
           make ${{ matrix.build }}
 
       - name: "Upload ${{ matrix.build }} executables"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.arch }}-${{ matrix.build }}
           path: ${{ github.workspace }}/**/tools/**/*.exe

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -119,7 +119,7 @@ jobs:
           ./build.sh
 
       - name: "Upload built ROMs to artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: roms
           path: |

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -1,3 +1,6 @@
+# Copyright (c) libdragon and contributers 2023
+# See LICENSE file in the project root for full license information.
+
 on:
   workflow_call:
     secrets:
@@ -17,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Create a lower cased version of the repo name. This is required
       # because Docker supports only lowercase names in the registry, while
@@ -25,9 +28,9 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "::set-output name=repository_name::${GITHUB_REPOSITORY,,}"
-          echo "::set-output name=default_ref::${{ format('refs/heads/{0}', github.event.repository.default_branch) }}"
-          echo "::set-output name=default_remote::${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}"
+          echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
+          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
       - name: Compare files
         uses: ./.github/actions/path-diff

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Using a full fetch so that the diff action can run.
 
       # Create a lower cased version of the repo name. This is required
       # because Docker supports only lowercase names in the registry, while

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Copyright (c) libdragon and contributers 2023
+# See LICENSE file in the project root for full license information.
+
 name: Build
 
 on: [push, pull_request]


### PR DESCRIPTION
The current CI workflow for documentation etc. has deprecations.

Found when building in a fork: https://github.com/networkfusion/libdragon/actions/runs/3925525406

![image](https://user-images.githubusercontent.com/11439699/212573260-de66313b-8fe3-4b0c-96b5-20f82fff8866.png)


This PR adds the necessary fixes.
See here for why: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

It also fixes 
* indentation (to use only spaces) to as it was a mixture of tabs and spaces. 
* improves build speed by using fetch-depth: 1 where possible.