### PR TITLE
Add generated assets to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ tools/n64tool
 tools/**/*.exe
 website/ref/
 
+## Generated assets
+examples/fontdemo/filesystem/*.font64
+tests/filesystem/*.sprite
+
 ## OSX junk
 .DS_Store
 .Trashes


### PR DESCRIPTION
Some assets are generated by the build and cause issues with submodules.

e.g.
![image](https://github.com/rasky/libdragon/assets/11439699/49a2e746-4528-4200-b5fa-5e70d7049ca4)
